### PR TITLE
Adding Zing Action to set up Java in place of default action to setup Java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,8 @@ jobs:
       uses: zing-actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Java Version
+      run: java -version
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Test with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 on:
   push:
     branches: [ master ]
-
 jobs:
   zulu_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  zulu_build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -16,6 +16,26 @@ jobs:
           ${{ runner.os }}-gradle-
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Test with Gradle
+      run: ./gradlew test
+    - name: Build with Gradle
+      run: ./gradlew build
+  zing_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Set up JDK 1.8
+      uses: zing-actions/setup-java@v1
       with:
         java-version: 1.8
     - name: Grant execute permission for gradlew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,27 +3,7 @@ on:
   push:
     branches: [ master ]
 jobs:
-  zulu_build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Test with Gradle
-      run: ./gradlew test
-    - name: Build with Gradle
-      run: ./gradlew build
-  zing_build:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Added zing-actions/setup-java@v1 to use zing java by replacing the line actions/checkout@v2